### PR TITLE
Bug Fix in Division operation

### DIFF
--- a/include/real/real_data.hpp
+++ b/include/real/real_data.hpp
@@ -183,9 +183,11 @@ namespace boost {
                     bool deviation_upper_boundary, deviation_lower_boundary;
 
                     /* if the interval contains zero, iterate until it doesn't, or until maximum_precision. */
-                    while (!ro.get_rhs_itr().get_interval().positive() &&
-                           !ro.get_rhs_itr().get_interval().negative() &&
-                           _precision <= this->maximum_precision())
+                   while (((!ro.get_rhs_itr().get_interval().positive() 
+                            && !ro.get_rhs_itr().get_interval().negative() ) 
+                            || ro.get_rhs_itr().get_interval().lower_bound == literals::zero_exact<T>
+                            || ro.get_rhs_itr().get_interval().upper_bound == literals::zero_exact<T> ) 
+                            && _precision <= this->maximum_precision())
                         ++(*this);
 
                     /* if the interval contains zero after iterating until max precision, throw,


### PR DESCRIPTION
Division operation was showing "Division by zero" error when denomiator was a multiplication operation and initial iterations of that operation were giving zero as lower bound.
For example in this expression 2.4/(6.87*1.45), here (6.87*1.45) will give lower bound as zero for intial iteration because 1.45 will give [0, 2] in first iteration. Division should not throw any kind of error for such expressions.